### PR TITLE
chore: add decorator typing

### DIFF
--- a/aioelectricitymaps/decorators.py
+++ b/aioelectricitymaps/decorators.py
@@ -1,12 +1,21 @@
 """Decorators for aioelectricitymaps."""
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any, ParamSpec, TypeVar
 
 from .exceptions import SwitchedToLegacyAPI
 
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
-def retry_legacy(func):
+
+def retry_legacy(
+    func: Callable[_P, Coroutine[Any, Any, _R]]
+) -> Callable[_P, Coroutine[Any, Any, _R]]:
     """Decorator to retry a function with the legacy API if SwitchedToLegacyAPI is raised."""
 
-    async def inner(*args, **kwargs):
+    async def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         try:
             result = await func(*args, **kwargs)
         except SwitchedToLegacyAPI:


### PR DESCRIPTION
The untyped decorator causes `no-any-return` errors upstream. See https://github.com/home-assistant/core/pull/106888
The type ignores can be easily removed when the library is updated.