### PR TITLE
Make zone key upper case in latest_carbon_intensity_by_country_code

### DIFF
--- a/aioelectricitymaps/electricitymaps.py
+++ b/aioelectricitymaps/electricitymaps.py
@@ -89,7 +89,7 @@ class ElectricityMaps:
         code: str,
     ) -> CarbonIntensityResponse:
         """Get carbon intensity by country code."""
-        result = await self._get(ApiEndpoints.CARBON_INTENSITY, {"zone": code})
+        result = await self._get(ApiEndpoints.CARBON_INTENSITY, {"zone": code.upper()})
         return CarbonIntensityResponse.from_json(result)
 
     async def zones(self) -> dict[str, Zone]:


### PR DESCRIPTION
The API currently only accepts uppercase zone keys so this PR makes a small change to ensure that the package always sends the zone keys as uppercase.